### PR TITLE
updating DMG destination when temp image location is set

### DIFF
--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -181,7 +181,7 @@ class AcquisitionMethod(ABC):
         return details
 
     def _gather_hardware_info(self) -> str:
-        _, hardware_info = self._run_silent(["system_profiler", "SPHardwareDataType"])
+        _, hardware_info = self._run_silent(["system_profiler", "SPSoftwareDataType", "SPHardwareDataType", "SPNVMeDataType", "SPStorageDataType"])
         return hardware_info
 
     def _create_temporary_image(self, report: Report) -> bool:

--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -341,9 +341,9 @@ class AcquisitionMethod(ABC):
                 + [
                     separator,
                     f"Computed hashes ({report.result.path}):",
-                    f"    - MD5: {report.result.md5}",
-                    f"    - SHA1: {report.result.sha1}",
-                    f"    - SHA256: {report.result.sha256}",
+                    f"    - MD5: {report.result.md5.upper()}",
+                    f"    - SHA1: {report.result.sha1.upper()}",
+                    f"    - SHA256: {report.result.sha256.upper()}",
                 ]
             ):
                 output.write(line + "\n")

--- a/fuji.py
+++ b/fuji.py
@@ -96,6 +96,7 @@ class InputWindow(wx.Frame):
         self.tmp_picker.SetInitialDirectory("/Volumes")
         if os.path.isdir(PARAMS.tmp):
             self.tmp_picker.SetPath(str(PARAMS.tmp))
+        self.tmp_picker.Bind(wx.EVT_DIRPICKER_CHANGED, self.on_tmp_location_changed)
         destination_label = wx.StaticText(panel, label="DMG destination:")
         self.destination_picker = wx.DirPickerCtrl(panel)
         self.destination_picker.SetInitialDirectory("/Volumes")
@@ -175,6 +176,11 @@ class InputWindow(wx.Frame):
         # Bind close
         self.Bind(wx.EVT_CLOSE, self.on_close)
 
+    def on_tmp_location_changed(self, event):
+        temp_location = self.tmp_picker.GetPath()
+        destination_location = self.destination_picker.GetPath()
+        if not destination_location:
+            self.destination_picker.SetPath(temp_location)
     def _validate_image_name(self, event):
         key = event.GetKeyCode()
         valid_characters = "-_" + string.ascii_letters + string.digits


### PR DESCRIPTION
In consultation with you, here is my pull request for the changes to Fuji.

Here:

Change the “DMG Destination” to the value from “Temp Image Location” if the value “DMG Destination” is still empty. 