### PR TITLE
Bruno fischer germany patch empty (space characters) in "Source", "Temp image Location", "DMG destination" fields

### DIFF
--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -181,7 +181,7 @@ class AcquisitionMethod(ABC):
         return details
 
     def _gather_hardware_info(self) -> str:
-        _, hardware_info = self._run_silent(["system_profiler", "SPHardwareDataType"])
+        _, hardware_info = self._run_silent(["system_profiler", "SPSoftwareDataType", "SPHardwareDataType", "SPNVMeDataType", "SPStorageDataType"])
         return hardware_info
 
     def _create_temporary_image(self, report: Report) -> bool:

--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -341,9 +341,9 @@ class AcquisitionMethod(ABC):
                 + [
                     separator,
                     f"Computed hashes ({report.result.path}):",
-                    f"    - MD5: {report.result.md5}",
-                    f"    - SHA1: {report.result.sha1}",
-                    f"    - SHA256: {report.result.sha256}",
+                    f"    - MD5: {report.result.md5.upper()}",
+                    f"    - SHA1: {report.result.sha1.upper()}",
+                    f"    - SHA256: {report.result.sha256.upper()}",
                 ]
             ):
                 output.write(line + "\n")

--- a/fuji.py
+++ b/fuji.py
@@ -96,6 +96,7 @@ class InputWindow(wx.Frame):
         self.tmp_picker.SetInitialDirectory("/Volumes")
         if os.path.isdir(PARAMS.tmp):
             self.tmp_picker.SetPath(str(PARAMS.tmp))
+        self.tmp_picker.Bind(wx.EVT_DIRPICKER_CHANGED, self.on_tmp_location_changed)
         destination_label = wx.StaticText(panel, label="DMG destination:")
         self.destination_picker = wx.DirPickerCtrl(panel)
         self.destination_picker.SetInitialDirectory("/Volumes")
@@ -175,6 +176,11 @@ class InputWindow(wx.Frame):
         # Bind close
         self.Bind(wx.EVT_CLOSE, self.on_close)
 
+    def on_tmp_location_changed(self, event):
+        temp_location = self.tmp_picker.GetPath()
+        destination_location = self.destination_picker.GetPath()
+        if not destination_location:
+            self.destination_picker.SetPath(temp_location)
     def _validate_image_name(self, event):
         key = event.GetKeyCode()
         valid_characters = "-_" + string.ascii_letters + string.digits

--- a/fuji.py
+++ b/fuji.py
@@ -196,9 +196,9 @@ class InputWindow(wx.Frame):
         PARAMS.examiner = self.examiner_text.Value
         PARAMS.notes = self.notes_text.Value
         PARAMS.image_name = self.output_text.Value
-        PARAMS.source = Path(self.source_picker.GetPath())
-        PARAMS.tmp = Path(self.tmp_picker.GetPath())
-        PARAMS.destination = Path(self.destination_picker.GetPath())
+        PARAMS.source = Path(self.source_picker.GetPath().strip())
+        PARAMS.tmp = Path(self.tmp_picker.GetPath().strip())
+        PARAMS.destination = Path(self.destination_picker.GetPath().strip())
         PARAMS.sound = self.sound_checkbox.GetValue()
         self.method = METHODS[self.method_choice.GetSelection()]
 


### PR DESCRIPTION
If a user enters a blank character in the “Source”, “Temp Image Location” or “DMG Destination” fields in Fuji, the system uses 
Line 205 self.Hide()
is executed, but the app can no longer be used. 

Error: 

`  File "/Fuji/fuji.py", line 206, in on_continue`
`    OVERVIEW_WINDOW.update_overview()`
`  File "/Users/franzgraummann/PycharmProjects/Fuji/fuji.py", line 293, in update_overview`
`    result = check.execute(PARAMS)`
`             ^^^^^^^^^^^^^^^^^^^^^`
`  File "/Fuji/checks/free_space.py", line 50, in execute`
`    destination_free = self._get_free_space(params.destination)`
`                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`
`  File "/Users/franzgraummann/PycharmProjects/Fuji/checks/free_space.py", line 18, in _get_free_space`
`    statvfs = os.statvfs(path)`
`              ^^^^^^^^^^^^^^^^`
`FileNotFoundError: [Errno 2] No such file or directory: ' '`

This behavior is prevented with .stripe().