### PR TITLE
Update fuji.py - Intercepting spaces

### DIFF
--- a/fuji.py
+++ b/fuji.py
@@ -190,9 +190,9 @@ class InputWindow(wx.Frame):
         PARAMS.examiner = self.examiner_text.Value
         PARAMS.notes = self.notes_text.Value
         PARAMS.image_name = self.output_text.Value
-        PARAMS.source = Path(self.source_picker.GetPath())
-        PARAMS.tmp = Path(self.tmp_picker.GetPath())
-        PARAMS.destination = Path(self.destination_picker.GetPath())
+        PARAMS.source = Path(self.source_picker.GetPath().strip())
+        PARAMS.tmp = Path(self.tmp_picker.GetPath().strip())
+        PARAMS.destination = Path(self.destination_picker.GetPath().strip())
         PARAMS.sound = self.sound_checkbox.GetValue()
         self.method = METHODS[self.method_choice.GetSelection()]
 


### PR DESCRIPTION
If a user enters a blank character in the “Source”, “Temp Image Location” or “DMG Destination” fields in Fuji, the system uses Line 205 self.Hide()
is executed, but the app can no longer be used.

Error:

`  File "/Fuji/fuji.py", line 206, in on_continue`
`    OVERVIEW_WINDOW.update_overview()`
`  File "/Fuji/fuji.py", line 293, in update_overview`
`    result = check.execute(PARAMS)`
`             ^^^^^^^^^^^^^^^^^^^^^`
`  File "/Fuji/checks/free_space.py", line 50, in execute`
`    destination_free = self._get_free_space(params.destination)`
`                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`
`  File "/Fuji/checks/free_space.py", line 18, in _get_free_space`
`    statvfs = os.statvfs(path)`
`              ^^^^^^^^^^^^^^^^`
`FileNotFoundError: [Errno 2] No such file or directory: ' '`

This behavior is prevented with .stripe().