### PR TITLE
A check mark with the designation “create an un-compressed (raw) acquisition .dmg-file” inserted

### DIFF
--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -16,7 +16,6 @@ from typing import IO, List, Tuple
 from meta import AUTHOR, VERSION
 from shared.utils import command_to_properties, lines_to_properties
 
-
 @dataclass
 class Parameters:
     case: str = ""
@@ -306,8 +305,12 @@ class AcquisitionMethod(ABC):
         print("\nConverting", self.temporary_path, "->", self.output_path)
         sparseimage = f"{self.temporary_path}"
         dmg = f"{self.output_path}"
+        if params.compressed:
+            dmgformat = "UDRO"
+        else:
+            dmgformat = "UDZO"
         result = self._run_status(
-            ["hdiutil", "convert", sparseimage, "-format", "UDZO", "-o", dmg]
+            ["hdiutil", "convert", sparseimage, "-format", dmgformat, "-o", dmg]
         )
 
         success = result == 0

--- a/fuji.py
+++ b/fuji.py
@@ -349,7 +349,7 @@ class InputWindow(wx.Frame):
             description_text.SetLabelMarkup(description_label)
             self.description_texts.append(description_text)
 
-        # Sound checkbox
+        # compressed dmg file checkbox
         self.compressed_checkbox = wx.CheckBox(
             panel, label="Create an un-compressed (raw) acquisition .dmg-file"
         )

--- a/fuji.py
+++ b/fuji.py
@@ -350,6 +350,12 @@ class InputWindow(wx.Frame):
             self.description_texts.append(description_text)
 
         # Sound checkbox
+        self.compressed_checkbox = wx.CheckBox(
+            panel, label="Create an un-compressed (raw) acquisition .dmg-file"
+        )
+        self.compressed_checkbox.SetValue(False)
+
+        # Sound checkbox
         self.sound_checkbox = wx.CheckBox(
             panel, label="Play loud sound when acquisition is completed"
         )
@@ -402,6 +408,7 @@ class InputWindow(wx.Frame):
             vbox.Add(description_text, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         vbox.Add((0, 20))
+        vbox.Add(self.compressed_checkbox, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 10)
         vbox.Add(self.sound_checkbox, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 10)
         vbox.Add(continue_btn, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 20)
         panel.SetSizer(vbox)
@@ -449,6 +456,7 @@ class InputWindow(wx.Frame):
         PARAMS.tmp = Path(self.tmp_picker.GetPath().strip())
         PARAMS.destination = Path(self.destination_picker.GetPath().strip())
         PARAMS.sound = self.sound_checkbox.GetValue()
+        PARAMS.compressed = self.compressed_checkbox.GetValue()
         self.method = METHODS[self.method_choice.GetSelection()]
 
         self.Hide()
@@ -517,6 +525,7 @@ class OverviewWindow(wx.Frame):
             "Temp image location": PARAMS.tmp,
             "DMG destination": PARAMS.destination,
             "Acquisition method": INPUT_WINDOW.method.name,
+            "Compressed Acquisition": "No" if PARAMS.compressed else "Yes",
             "Play sound": "Yes" if PARAMS.sound else "No",
         }
 


### PR DESCRIPTION
A check mark with the designation “create an un-compressed (raw) acquisition .dmg-file” inserted, default - False
hdiutil convert -format “UDRO” if ticked, otherwise “UDZO”
so X-Ways Forensics can also open the created .dmg file.
<img width="606" alt="grafik" src="https://github.com/user-attachments/assets/1d8751f2-636f-4e5c-b45d-db130a7f35dd" />
<img width="910" alt="grafik" src="https://github.com/user-attachments/assets/5efec0ea-788c-4e8d-b801-4f86a703c165" />
