### PR TITLE
Add 2 Hooks

### DIFF
--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -16,7 +16,6 @@ from typing import IO, List, Tuple
 from meta import AUTHOR, VERSION
 from shared.utils import command_to_properties, lines_to_properties
 
-
 @dataclass
 class Parameters:
     case: str = ""
@@ -306,8 +305,12 @@ class AcquisitionMethod(ABC):
         print("\nConverting", self.temporary_path, "->", self.output_path)
         sparseimage = f"{self.temporary_path}"
         dmg = f"{self.output_path}"
+        if params.compressed:
+            dmgformat = "UDRO"
+        else:
+            dmgformat = "UDZO"
         result = self._run_status(
-            ["hdiutil", "convert", sparseimage, "-format", "UDZO", "-o", dmg]
+            ["hdiutil", "convert", sparseimage, "-format", dmgformat, "-o", dmg]
         )
 
         success = result == 0

--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -84,7 +84,7 @@ class AcquisitionMethod(ABC):
             return ""
 
     def _create_shell_process(
-            self, arguments: List[str], awake=True, tee: Path = None
+        self, arguments: List[str], awake=True, tee: Path = None
     ) -> Popen[str]:
         if awake:
             arguments = ["caffeinate", "-dimsu"] + arguments
@@ -111,7 +111,7 @@ class AcquisitionMethod(ABC):
         return p.returncode, p.stdout
 
     def _run_process(
-            self, arguments: List[str], awake=True, buffer_size=1024000, tee: Path = None
+        self, arguments: List[str], awake=True, buffer_size=1024000, tee: Path = None
     ) -> Tuple[int, str]:
         # Run a process in plain sight. Return its status code and output.
         p = self._create_shell_process(arguments, awake=awake, tee=tee)
@@ -135,7 +135,7 @@ class AcquisitionMethod(ABC):
         return p.returncode, output
 
     def _run_status(
-            self, arguments: List[str], awake=True, buffer_size=1024000, tee: Path = None
+        self, arguments: List[str], awake=True, buffer_size=1024000, tee: Path = None
     ) -> int:
         # Run a process in plain sight. Return its status code.
         p = self._create_shell_process(arguments, awake=awake, tee=tee)

--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -390,9 +390,9 @@ class AcquisitionMethod(ABC):
         output_files = []
         if len(report.output_files):
             output_files = [
-                               separator,
-                               "Generated files:",
-                           ] + [f"    - {file}" for file in report.output_files]
+                separator,
+                "Generated files:",
+            ] + [f"    - {file}" for file in report.output_files]
 
         hashes = []
         if report.result:

--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -406,30 +406,30 @@ class AcquisitionMethod(ABC):
 
         with open(self.output_report, "w") as output:
             for line in (
-                    [
-                        "Fuji - Forensic Unattended Juicy Imaging",
-                        f"Version {VERSION} by {AUTHOR}",
-                        "Acquisition log",
-                        separator,
-                        f"Case name: {report.parameters.case}",
-                        f"Examiner: {report.parameters.examiner}",
-                        f"Notes: {report.parameters.notes}",
-                        separator,
-                        f"Start time: {report.start_time}",
-                        f"End time: {report.end_time}",
-                        f"Source: {report.parameters.source}",
-                        f"Acquisition method: {report.method.name}",
-                        f"Imagefile type: {'uncompressed (UDRW)' if report.parameters.compressed else 'compressed (UDZO)'}",
-                        f"temporary image file: {'delete' if report.parameters.state_temporary_image else 'keep'} after acquisition",
-                        separator,
-                        report.hardware_info,
-                        separator,
-                        "Volume:",
-                        "",
-                        report.path_details.disk_info,
-                    ]
-                    + output_files
-                    + hashes
+                [
+                    "Fuji - Forensic Unattended Juicy Imaging",
+                    f"Version {VERSION} by {AUTHOR}",
+                    "Acquisition log",
+                    separator,
+                    f"Case name: {report.parameters.case}",
+                    f"Examiner: {report.parameters.examiner}",
+                    f"Notes: {report.parameters.notes}",
+                    separator,
+                    f"Start time: {report.start_time}",
+                    f"End time: {report.end_time}",
+                    f"Source: {report.parameters.source}",
+                    f"Acquisition method: {report.method.name}",
+                    f"Imagefile type: {'uncompressed (UDRW)' if report.parameters.compressed else 'compressed (UDZO)'}",
+                    f"temporary image file: {'delete' if report.parameters.state_temporary_image else 'keep'} after acquisition",
+                    separator,
+                    report.hardware_info,
+                    separator,
+                    "Volume:",
+                    "",
+                    report.path_details.disk_info,
+                ]
+                + output_files
+                + hashes
             ):
                 output.write(line + "\n")
 

--- a/fuji.py
+++ b/fuji.py
@@ -349,7 +349,7 @@ class InputWindow(wx.Frame):
             description_text.SetLabelMarkup(description_label)
             self.description_texts.append(description_text)
 
-        # Sound checkbox
+        # compressed dmg file checkbox
         self.compressed_checkbox = wx.CheckBox(
             panel, label="Create an un-compressed (raw) acquisition .dmg-file"
         )

--- a/fuji.py
+++ b/fuji.py
@@ -350,6 +350,12 @@ class InputWindow(wx.Frame):
             self.description_texts.append(description_text)
 
         # Sound checkbox
+        self.compressed_checkbox = wx.CheckBox(
+            panel, label="Create an un-compressed (raw) acquisition .dmg-file"
+        )
+        self.compressed_checkbox.SetValue(False)
+
+        # Sound checkbox
         self.sound_checkbox = wx.CheckBox(
             panel, label="Play loud sound when acquisition is completed"
         )
@@ -402,6 +408,7 @@ class InputWindow(wx.Frame):
             vbox.Add(description_text, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         vbox.Add((0, 20))
+        vbox.Add(self.compressed_checkbox, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 10)
         vbox.Add(self.sound_checkbox, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 10)
         vbox.Add(continue_btn, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 20)
         panel.SetSizer(vbox)
@@ -449,6 +456,7 @@ class InputWindow(wx.Frame):
         PARAMS.tmp = Path(self.tmp_picker.GetPath().strip())
         PARAMS.destination = Path(self.destination_picker.GetPath().strip())
         PARAMS.sound = self.sound_checkbox.GetValue()
+        PARAMS.compressed = self.compressed_checkbox.GetValue()
         self.method = METHODS[self.method_choice.GetSelection()]
 
         self.Hide()
@@ -517,6 +525,7 @@ class OverviewWindow(wx.Frame):
             "Temp image location": PARAMS.tmp,
             "DMG destination": PARAMS.destination,
             "Acquisition method": INPUT_WINDOW.method.name,
+            "Compressed Acquisition": "No" if PARAMS.compressed else "Yes",
             "Play sound": "Yes" if PARAMS.sound else "No",
         }
 

--- a/fuji.py
+++ b/fuji.py
@@ -133,7 +133,7 @@ class DevicesWindow(wx.Frame):
             if not line.startswith("/dev/disk"):
                 continue
             identifier, size, used, free, _, _, _, _, mount_point = re.split(
-                "\s+", line, maxsplit=8
+                r"\s+", line, maxsplit=8
             )
             short_identifier = identifier[5:]
             mount_info[short_identifier] = DiskSpaceInfo(
@@ -351,9 +351,15 @@ class InputWindow(wx.Frame):
 
         # compressed dmg file checkbox
         self.compressed_checkbox = wx.CheckBox(
-            panel, label="Create an un-compressed (raw) acquisition .dmg-file"
+            panel, label="Create an un-compressed (UDRW) acquisition .dmg-file"
         )
         self.compressed_checkbox.SetValue(False)
+
+        # keep/delete temporary sparseimage file after acquisition
+        self.state_temporary_image_checkbox = wx.CheckBox(
+            panel, label="Delete temporary image file after acquisition"
+        )
+        self.state_temporary_image_checkbox.SetValue(False)
 
         # Sound checkbox
         self.sound_checkbox = wx.CheckBox(
@@ -409,6 +415,7 @@ class InputWindow(wx.Frame):
 
         vbox.Add((0, 20))
         vbox.Add(self.compressed_checkbox, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 10)
+        vbox.Add(self.state_temporary_image_checkbox, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 10)
         vbox.Add(self.sound_checkbox, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 10)
         vbox.Add(continue_btn, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.BOTTOM, 20)
         panel.SetSizer(vbox)
@@ -457,6 +464,7 @@ class InputWindow(wx.Frame):
         PARAMS.destination = Path(self.destination_picker.GetPath().strip())
         PARAMS.sound = self.sound_checkbox.GetValue()
         PARAMS.compressed = self.compressed_checkbox.GetValue()
+        PARAMS.state_temporary_image = self.state_temporary_image_checkbox.GetValue()
         self.method = METHODS[self.method_choice.GetSelection()]
 
         self.Hide()
@@ -525,7 +533,8 @@ class OverviewWindow(wx.Frame):
             "Temp image location": PARAMS.tmp,
             "DMG destination": PARAMS.destination,
             "Acquisition method": INPUT_WINDOW.method.name,
-            "Compressed Acquisition": "No" if PARAMS.compressed else "Yes",
+            "Imagefile type": "uncompressed (UDRW)" if PARAMS.compressed else "compressed (UDZO)",
+            "Temporary image file": f"{'delete' if PARAMS.state_temporary_image else 'keep'} after acquisition",
             "Play sound": "Yes" if PARAMS.sound else "No",
         }
 


### PR DESCRIPTION
Hello @Lazza,

i added 2 Hooks for Fuji.
<img width="606" alt="grafik" src="https://github.com/user-attachments/assets/ccbef34d-0e8f-4f43-b912-0385b98e85e3" />

1. Hook "Create an un-compressed (UDRW) acquisition .dmg-file" (Standard: false)
2. Hook "Delete temporary image file after acquisition" (Standard: false)

Why?
The first Hook: 
a commonly used forensic tool called X-Ways Forensics does not support the UDZO image format, only UDRW is supported. Therefore I have added the option to select it here. Leier I was not able to calculate the effect on “Free Space”. With a volume (APFS -100MB with 10 MB used memory) the .dmg was then approx. 1.2 GB in size. 
You are also welcome to write to X-Ways Forensics (mail@x-ways.com) and ask for additions. You can also point out the compression. (The UDZO Image is an UDIF zlib-compressed read-only image).

The second Hook:
After creating the image, Fuji can also delete the temporary image (.sparsefile) if you like. Since it is optional, you can have it deleted immediately.

the values of the hooks are also available on the overview page.
<img width="351" alt="grafik" src="https://github.com/user-attachments/assets/3671bbca-97a3-4231-81c8-2aaa1efcedb9" />
or - here standard
<img width="335" alt="grafik" src="https://github.com/user-attachments/assets/d3fee26b-6fa0-464d-a012-79e928777714" />

So it could maybe the version 1.2

I am pleased to hear from you.

By the way, the backup here was successfully performed with a MacBook Pro (M1) with MacOS 15.3.2.