### PR TITLE
Run shell subprocesses under a pty so rsync/asr progress flushes live

### DIFF
--- a/acquisition/abstract.py
+++ b/acquisition/abstract.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import hashlib
 import os
+import pty
 import re
 import selectors
 import shlex
@@ -95,7 +96,11 @@ class AcquisitionMethod(ABC):
 
         events = sel.select(0.125)
         if events:
-            data = os.read(file.fileno(), limit)
+            try:
+                data = os.read(file.fileno(), limit)
+            except OSError:
+                # Pty master returns EIO on Linux once the slave is closed.
+                return ""
             return data.decode(encoding, "ignore")
         else:
             # Timeout occurred
@@ -113,13 +118,26 @@ class AcquisitionMethod(ABC):
         command = shlex.join(arguments) + " 2>&1"
         if redirect is not None:
             command = command + " > " + shlex.quote(redirect.as_posix())
+            return subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                shell=True,
+                universal_newlines=True,
+            )
 
+        # Run the child under a pseudo-tty so tools that detect a non-tty stdout
+        # (rsync --progress, asr, hdiutil) line-flush their progress output
+        # instead of block-buffering it. Without a pty the progress appears
+        # stuck until the child's stdio buffer fills or the process exits.
+        master_fd, slave_fd = pty.openpty()
         p = subprocess.Popen(
             command,
-            stdout=subprocess.PIPE,
+            stdout=slave_fd,
+            stderr=slave_fd,
             shell=True,
-            universal_newlines=True,
         )
+        os.close(slave_fd)
+        p.stdout = os.fdopen(master_fd, "r", encoding="utf-8", errors="replace")
         return p
 
     def _run_silent(self, arguments: List[str], awake=True) -> Tuple[int, str]:
@@ -151,7 +169,10 @@ class AcquisitionMethod(ABC):
                 output = output + out
 
             if p.poll() != None:
-                out = stdout.read()
+                try:
+                    out = stdout.read()
+                except OSError:
+                    out = ""
                 sys.stdout.write(out)
                 output = output + out
                 break
@@ -177,7 +198,10 @@ class AcquisitionMethod(ABC):
                 sys.stdout.write(out)
 
             if p.poll() != None:
-                out = stdout.read()
+                try:
+                    out = stdout.read()
+                except OSError:
+                    out = ""
                 sys.stdout.write(out)
                 break
 


### PR DESCRIPTION
## Problem

When running an acquisition with the Rsync or ASR method, the on-screen progress appears to hang for long stretches and then dump a burst of output, or just sits silent until the process finishes. This is not a hang — the acquisition is making progress — but to the user the UI looks frozen.

## Root cause

`acquisition/abstract.py::_create_shell_process` spawns the child with `subprocess.Popen(..., stdout=subprocess.PIPE, shell=True)`. `rsync --progress`, `asr restore`, and `hdiutil convert` all check whether stdout is a tty and switch to **block buffering** at the libc level when it isn't. Their progress output (rsync's `\r`-rewriting line, asr's `..10..20..100` dots, hdiutil's percent) accumulates in the child's stdio buffer and only reaches Fuji when the buffer fills (typically 4–64 KB) or the process exits.

The read side in `_run_process` / `_run_status` is fine — it uses `selectors` + `os.read(fileno, …)` to bypass Python-level buffering and polls every 100 ms. The bytes simply aren't there to read.

Both methods hit this path:
- `RsyncMethod.execute` → `_run_status` → `_create_shell_process(arguments)` (no redirect)
- `AsrMethod.execute` → `_run_process` → `_create_shell_process(arguments)` (no redirect)

The same problem also slows feedback during `hdiutil convert` in `_generate_dmg`.

## Fix

Allocate a pseudo-tty in `_create_shell_process` and pass the slave fd as the child's stdout/stderr when there is **no** shell-level redirect. The child sees a tty, line-flushes its progress, and the existing select-based read loop delivers it live.

- The `redirect is not None` branch (used only by `_run_dots`, which sends output to `/dev/null` and never reads it) is preserved verbatim, so dotted-progress paths are unaffected.
- `os.read` on a pty master raises `OSError(EIO)` on Linux once the slave is closed and returns clean EOF on macOS. The post-exit reads in `_limited_read`, `_run_process`, and `_run_status` are wrapped in `try/except OSError` so both behaviours are handled.

## Test

Smoke-tested on Linux with a Python child that writes one line per 400 ms **without** `flush=True` — which is exactly the block-buffered-when-piped scenario:

```
[t+0.10s] 'tick 0\r\n'
[t+0.43s] 'tick 1\r\n'
[t+0.81s] 'tick 2\r\n'
[t+1.21s] 'tick 3\r\n'
[t+1.61s] 'tick 4\r\n'
```

Lines now arrive at the cadence the child writes them. Without the pty they would all land together at `t+2s` when the child exits.

⚠️ **Not tested on macOS hardware** — I don't have a Mac available. The Python-level behaviour is portable (Linux and macOS both implement `pty.openpty()` and `os.read` on pty masters), and the EIO handling makes the Linux behaviour safe too, but a real-Mac sanity check before merge would be appreciated.

## Scope

Single file: `acquisition/abstract.py`. 29 insertions, 5 deletions.