### PR TITLE
Prevent Ditto acquisition from hanging on named pipes in recovery

### DIFF
--- a/acquisition/ditto.py
+++ b/acquisition/ditto.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from acquisition.abstract import AcquisitionMethod, Parameters, Report
 from shared.environment import RECOVERY
+from shared.fifos import keep_fifos_open
 
 
 class DittoMethod(AcquisitionMethod):
@@ -28,7 +29,8 @@ class DittoMethod(AcquisitionMethod):
         if not source_str.endswith("/"):
             source_str = source_str + "/"
         command = ["ditto", "-X", "-V", source_str, temporary_image.mount]
-        status = self._run_status(command)
+        with keep_fifos_open(params.source):
+            status = self._run_status(command)
 
         # We cannot rely on the exit code, because it will probably contain some
         # errors if a few files cannot be copied.

--- a/shared/fifos.py
+++ b/shared/fifos.py
@@ -1,0 +1,59 @@
+"""Prevent Ditto's metadata opens from waiting for absent FIFO writers."""
+
+from contextlib import ExitStack, contextmanager
+import errno
+import os
+from pathlib import Path
+import stat
+from typing import Callable, Iterator
+
+
+def _find_fifos(source: Path, notify: Callable[[str], None]) -> Iterator[Path]:
+    # Match ditto -X: follow the source argument, but neither symlinks inside
+    # it nor directories on other devices (including the destination image).
+    source = source.resolve(strict=True)
+    device = source.stat().st_dev
+    pending = [source]
+    while pending:
+        directory = pending.pop()
+        try:
+            with os.scandir(directory) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_symlink() or entry.is_file(follow_symlinks=False):
+                            continue
+                        info = entry.stat(follow_symlinks=False)
+                        if info.st_dev != device:
+                            continue
+                        if stat.S_ISDIR(info.st_mode):
+                            pending.append(Path(entry.path))
+                        elif stat.S_ISFIFO(info.st_mode):
+                            yield Path(entry.path)
+                    except OSError as error:
+                        notify(f"Cannot inspect {entry.path!r} for named pipes: {error}")
+        except OSError as error:
+            # Ditto will report any unreadable directories during the copy.
+            notify(f"Cannot scan {str(directory)!r} for named pipes: {error}")
+
+
+@contextmanager
+def keep_fifos_open(
+    source: Path, notify: Callable[[str], None] = print
+) -> Iterator[None]:
+    """Hold existing FIFOs open during a copy, without reading or writing data.
+
+    Tahoe's Ditto can block in open() on Postfix FIFOs before ignoring them.
+    A nonblocking read/write descriptor supplies the missing peer even in
+    Recovery. Keep it open until Ditto exits so the workaround does not race
+    with its traversal. Never create a path or follow a FIFO symlink.
+    """
+    with ExitStack() as descriptors:
+        for path in _find_fifos(source, notify):
+            # Do not ignore open failures: proceeding with an unguarded FIFO
+            # could hang the acquisition. ExitStack also cleans up on failure.
+            fd = os.open(path, os.O_RDWR | os.O_NONBLOCK | os.O_NOFOLLOW)
+            descriptors.callback(os.close, fd)
+            if not stat.S_ISFIFO(os.fstat(fd).st_mode):
+                raise OSError(errno.EINVAL, "Named pipe changed during scan", str(path))
+            notify(f"Guarding named pipe (no data read or written): {str(path)!r}")
+        yield

--- a/tests/test_ditto.py
+++ b/tests/test_ditto.py
@@ -1,0 +1,117 @@
+import errno
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from acquisition.abstract import Parameters, Report, SparseInfo
+from acquisition.ditto import DittoMethod
+
+
+@unittest.skipUnless(hasattr(os, "mkfifo"), "Requires Unix named pipes")
+class DittoMethodTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="fuji-ditto-")
+        self.addCleanup(self.temp.cleanup)
+        self.source = Path(self.temp.name) / "Test Data"
+        self.source.mkdir()
+        self.fifo = self.source / "pickup"
+        os.mkfifo(self.fifo)
+        self.method = DittoMethod()
+        self.params = Parameters(source=self.source)
+        self.report = Report(self.params, self.method)
+        self.image = SparseInfo(
+            Path(self.temp.name) / "test.sparseimage",
+            "/dev/disk-test",
+            "/dev/disk-test-s1",
+            str(Path(self.temp.name) / "Test Copy"),
+        )
+        self.method._initialize_report = Mock(return_value=self.report)
+        self.method._create_temporary_image = Mock(return_value=self.image)
+        self.method._run_status = Mock(return_value=0)
+        self.method._pack_and_hash = Mock(return_value=self.report)
+
+    def assert_guard_active(self):
+        # A nonblocking writer only opens successfully while a reader exists.
+        fd = os.open(self.fifo, os.O_WRONLY | os.O_NONBLOCK)
+        os.close(fd)
+
+    def assert_no_peer(self, fifo):
+        with self.assertRaises(OSError) as error:
+            fd = os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)
+            os.close(fd)
+        self.assertEqual(error.exception.errno, errno.ENXIO)
+
+    def test_guard_covers_copy_and_closes_before_packaging(self):
+        def copy(arguments):
+            self.assert_guard_active()
+            self.assertEqual(arguments, [
+                "ditto", "-X", "-V", f"{self.source}/", self.image.mount
+            ])
+            return 0
+
+        def package(report):
+            self.assert_no_peer(self.fifo)
+            self.assertIs(report, self.report)
+            return report
+
+        self.method._run_status.side_effect = copy
+        self.method._pack_and_hash.side_effect = package
+        self.assertIs(self.method.execute(self.params), self.report)
+        self.method._run_status.assert_called_once()
+        self.method._pack_and_hash.assert_called_once_with(self.report)
+
+    def test_setup_failure_closes_pipes_and_prevents_copy_and_packaging(self):
+        second = self.source / "qmgr"
+        os.mkfifo(second)
+        real_open = os.open
+        count = 0
+
+        def fail_second(path, flags):
+            nonlocal count
+            count += 1
+            if count == 2:
+                raise OSError(errno.EMFILE, "Too many open files")
+            return real_open(path, flags)
+
+        with patch("shared.fifos.os.open", side_effect=fail_second):
+            with self.assertRaises(OSError) as error:
+                self.method.execute(self.params)
+        self.assertEqual(error.exception.errno, errno.EMFILE)
+        self.method._run_status.assert_not_called()
+        self.method._pack_and_hash.assert_not_called()
+        self.assert_no_peer(self.fifo)
+        self.assert_no_peer(second)
+
+    def test_copy_exception_closes_pipes_and_prevents_packaging(self):
+        def fail_copy(arguments):
+            self.assert_guard_active()
+            raise RuntimeError("copy failed")
+
+        self.method._run_status.side_effect = fail_copy
+        with self.assertRaisesRegex(RuntimeError, "copy failed"):
+            self.method.execute(self.params)
+        self.method._run_status.assert_called_once()
+        self.method._pack_and_hash.assert_not_called()
+        self.assert_no_peer(self.fifo)
+
+    def test_missing_temporary_image_does_not_guard_copy_or_package(self):
+        self.method._create_temporary_image.return_value = None
+        with patch("acquisition.ditto.keep_fifos_open") as guard:
+            self.assertIs(self.method.execute(self.params), self.report)
+        guard.assert_not_called()
+        self.method._run_status.assert_not_called()
+        self.method._pack_and_hash.assert_not_called()
+        self.assert_no_peer(self.fifo)
+
+    def test_ordinary_nonzero_copy_status_still_packages(self):
+        self.method._run_status.return_value = 1
+        self.assertIs(self.method.execute(self.params), self.report)
+        self.method._run_status.assert_called_once()
+        self.method._pack_and_hash.assert_called_once_with(self.report)
+        self.assert_no_peer(self.fifo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fifos.py
+++ b/tests/test_fifos.py
@@ -1,0 +1,166 @@
+import errno
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from shared.fifos import keep_fifos_open
+
+
+@unittest.skipUnless(hasattr(os, "mkfifo"), "Requires Unix named pipes")
+class FifoGuardTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="fuji-fifo-")
+        self.addCleanup(self.temp.cleanup)
+        self.source = Path(self.temp.name) / "source"
+        self.source.mkdir()
+        self.fifo = self.source / "pickup"
+        os.mkfifo(self.fifo, 0o640)
+        self.messages = []
+
+    def assert_no_peer(self, fifo):
+        with self.assertRaises(OSError) as error:
+            fd = os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)
+            os.close(fd)
+        self.assertEqual(error.exception.errno, errno.ENXIO)
+
+    def test_releases_blocking_open_without_transferring_data(self):
+        before = self.fifo.stat()
+        # Model the blocking open reported by sample(1) on Tahoe. No writer
+        # exists until the guard starts, so this also checks the original hang.
+        script = """
+import os, sys
+print('ready', flush=True)
+fd = os.open(sys.argv[1], os.O_RDONLY)
+os.set_blocking(fd, False)
+try:
+    assert os.read(fd, 1) == b''
+except BlockingIOError:
+    pass
+os.close(fd)
+print('opened without data', flush=True)
+"""
+        with subprocess.Popen(
+            [sys.executable, "-c", script, str(self.fifo)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        ) as reader:
+            try:
+                self.assertEqual(reader.stdout.readline(), "ready\n")
+                with self.assertRaises(subprocess.TimeoutExpired):
+                    reader.communicate(timeout=0.2)
+                with keep_fifos_open(self.source, self.messages.append):
+                    output, errors = reader.communicate(timeout=5)
+                    self.assertEqual(reader.returncode, 0, errors)
+                    self.assertIn("opened without data", output)
+            finally:
+                if reader.poll() is None:
+                    reader.kill()
+                    reader.communicate()
+        after = self.fifo.stat()
+        self.assertTrue(stat.S_ISFIFO(after.st_mode))
+        for attribute in ("st_ino", "st_mode", "st_uid", "st_gid", "st_size", "st_mtime_ns"):
+            self.assertEqual(getattr(before, attribute), getattr(after, attribute))
+        self.assert_no_peer(self.fifo)
+
+    def test_nested_pipes_and_cleanup_after_copy_error(self):
+        nested = self.source / "private" / "var" / "spool" / "postfix" / "public"
+        nested.mkdir(parents=True)
+        second = nested / "qmgr"
+        os.mkfifo(second)
+        with self.assertRaisesRegex(RuntimeError, "copy failed"):
+            with keep_fifos_open(self.source, self.messages.append):
+                for fifo in (self.fifo, second):
+                    fd = os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)
+                    os.close(fd)
+                raise RuntimeError("copy failed")
+        for fifo in (self.fifo, second):
+            self.assert_no_peer(fifo)
+
+    def test_setup_failure_closes_previously_opened_pipes(self):
+        second = self.source / "qmgr"
+        os.mkfifo(second)
+        real_open = os.open
+        count = 0
+
+        def fail_second(path, flags):
+            nonlocal count
+            count += 1
+            if count == 2:
+                raise OSError(errno.EMFILE, "Too many open files")
+            return real_open(path, flags)
+
+        with patch("shared.fifos.os.open", side_effect=fail_second):
+            with self.assertRaises(OSError):
+                with keep_fifos_open(self.source, self.messages.append):
+                    self.fail("Copy must not start when a FIFO cannot be guarded")
+        self.assert_no_peer(self.fifo)
+        self.assert_no_peer(second)
+
+    def test_does_not_follow_internal_symlinks_or_create_paths(self):
+        outside = Path(self.temp.name) / "outside"
+        outside.mkdir()
+        outside_fifo = outside / "qmgr"
+        os.mkfifo(outside_fifo)
+        (self.source / "linked-directory").symlink_to(outside, target_is_directory=True)
+        (self.source / "linked-pipe").symlink_to(outside_fifo)
+        (self.source / "missing").symlink_to(outside / "absent")
+        with keep_fifos_open(self.source, self.messages.append):
+            self.assert_no_peer(outside_fifo)
+        self.assertEqual(len(self.messages), 1)
+        self.assertFalse((outside / "absent").exists())
+
+    def test_rejects_fifo_replaced_by_symlink(self):
+        target = self.source / "ordinary.txt"
+        target.write_text("untouched")
+        self.fifo.unlink()
+        self.fifo.symlink_to(target)
+        with patch("shared.fifos._find_fifos", return_value=iter([self.fifo])):
+            with self.assertRaises(OSError):
+                with keep_fifos_open(self.source, self.messages.append):
+                    self.fail("Copy must not start after FIFO replacement")
+        self.assertEqual(target.read_text(), "untouched")
+
+    @unittest.skipUnless(sys.platform == "darwin", "Requires macOS Ditto")
+    def test_ditto_preserves_fsevents_links_and_metadata(self):
+        events = self.source / ".fseventsd"
+        events.mkdir()
+        event = events / "0000000000000001"
+        payload = b"synthetic FSEvents fixture\x00\xff"
+        event.write_bytes(payload)
+        os.chmod(event, 0o640)
+        os.utime(event, (1700000000, 1700000000))
+        subprocess.run(["xattr", "-w", "com.fuji.test", "metadata", str(event)], check=True)
+        os.link(event, events / "hardlink")
+        (self.source / "event-link").symlink_to(".fseventsd/0000000000000001")
+        (self.source / "empty directory").mkdir()
+        unusual = self.source / "name with spaces\tand\na newline"
+        unusual.write_text("included")
+        destination = Path(self.temp.name) / "copy"
+        with keep_fifos_open(self.source, self.messages.append):
+            result = subprocess.run(
+                ["/usr/bin/ditto", "-X", "-V", str(self.source), str(destination)],
+                capture_output=True, text=True, timeout=15,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        copied = destination / ".fseventsd" / event.name
+        self.assertEqual(copied.read_bytes(), payload)
+        self.assertEqual(
+            subprocess.check_output(["xattr", "-p", "com.fuji.test", str(copied)]).strip(),
+            b"metadata",
+        )
+        self.assertEqual(copied.stat().st_mode, event.stat().st_mode)
+        self.assertEqual(copied.stat().st_mtime_ns, event.stat().st_mtime_ns)
+        self.assertEqual(copied.stat().st_ino, (copied.parent / "hardlink").stat().st_ino)
+        self.assertEqual(os.readlink(destination / "event-link"), ".fseventsd/0000000000000001")
+        self.assertTrue((destination / "empty directory").is_dir())
+        self.assertEqual((destination / unusual.name).read_text(), "included")
+        # Pipes are ignored by Ditto, as documented in its manual.
+        self.assertFalse((destination / "pickup").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ditto can hang during Recovery acquisition on macOS 26. This change scans the source for named pipes and holds nonblocking read/write descriptors open while Ditto runs. The guard does not read or write pipe data, and releases the descriptors when copying finishes or raises an exception. Credit to @jayvo12 for identifying the named-pipe cause and demonstrating the workaround in this issue comment (https://github.com/Lazza/Fuji/issues/36#issuecomment-5140232223), and to @derekeiri for independently confirming it(https://github.com/Lazza/Fuji/issues/36#issuecomment-5565961525). This PR automates that workaround.
